### PR TITLE
토큰 재발급 시, 액세스 토큰 만료 여부에 따라 안되던 로직 수정

### DIFF
--- a/src/main/java/com/yanolja/scbj/domain/member/service/MemberAuthService.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/service/MemberAuthService.java
@@ -6,6 +6,7 @@ import com.yanolja.scbj.domain.member.exception.InvalidRefreshTokenException;
 import com.yanolja.scbj.global.config.CustomUserDetailsService;
 import com.yanolja.scbj.global.config.jwt.JwtUtil;
 import com.yanolja.scbj.global.exception.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
@@ -21,19 +22,23 @@ public class MemberAuthService {
     }
 
     public TokenResponse refreshAccessToken(final RefreshRequest refreshRequest) {
+        String username = null;
+        try {
+            username = jwtUtil.extractUsername(refreshRequest.getAccessToken().substring(7));
+        } catch (ExpiredJwtException e) {
+            username = e.getClaims().getSubject();
+        } finally {
+            if (jwtUtil.isRefreshTokenValid(username, refreshRequest.getRefreshToken())) {
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
+                String newAccessToken = jwtUtil.generateToken(userDetails);
+                String newRefreshToken = jwtUtil.generateRefreshToken(username);
 
-        String username = jwtUtil.extractUsername(refreshRequest.getAccessToken().substring(7));
-        if (jwtUtil.isRefreshTokenValid(username, refreshRequest.getRefreshToken())) {
-            UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
-            String newAccessToken = jwtUtil.generateToken(userDetails);
-            String newRefreshToken = jwtUtil.generateRefreshToken(username);
-
-            return TokenResponse.builder().accessToken(newAccessToken).refreshToken(newRefreshToken)
-                .build();
-
-        } else {
-            throw new InvalidRefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
+                return TokenResponse.builder().accessToken(newAccessToken)
+                    .refreshToken(newRefreshToken)
+                    .build();
+            } else {
+                throw new InvalidRefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
+            }
         }
     }
-
 }


### PR DESCRIPTION
# 😁 Issue Link
- Close #100 
# 😆 To Reviewers
- 빠른 리뷰 부탁드려요 🥲
- 토큰 재발급 API 사용 시, 액세스 토큰이 만료여도 REFRESH TOKEN이 유효하면 재발급할 수 있게 수정!!
# 😚 Reference

# 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, **코드 수정을 강제하지 말아 주세요.**
* Reviewer 분들은 좋은 코드를 발견한 경우, **칭찬과 격려**를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **3일 이내에 진행**해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  * P1 : **꼭 반영해 주세요** (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  * P2 : 반영을 **적극적으로 고려**해 주시면 좋을 것 같아요 (Comment)
  * P3 : 이런 방법도 있을 것 같아요~ 등의 **사소한 의견**입니다 (Chore)
  