### PR TITLE
비밀번호 수정 시, 액세스 토큰이 필요없기 때문에 email을 활용한 수정

### DIFF
--- a/src/main/java/com/yanolja/scbj/domain/member/dto/request/MemberUpdatePasswordRequest.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/dto/request/MemberUpdatePasswordRequest.java
@@ -2,16 +2,23 @@ package com.yanolja.scbj.domain.member.dto.request;
 
 import com.yanolja.scbj.domain.member.validation.Password;
 import com.yanolja.scbj.domain.member.validation.ValidationGroups.PatternGroup;
+import jakarta.validation.constraints.Email;
 import lombok.Builder;
 
 public record MemberUpdatePasswordRequest(
+    @Email(message = "유효하지 않은 이메일입니다.",
+        regexp = EMAIL_REGEX, groups = PatternGroup.class)
+    String email,
     @Password(groups = PatternGroup.class)
     String password
 ) {
 
     @Builder
-    public MemberUpdatePasswordRequest(String password) {
+    public MemberUpdatePasswordRequest(String email, String password) {
+        this.email = email;
         this.password = password;
     }
+
+    private static final String EMAIL_REGEX = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
 
 }

--- a/src/main/java/com/yanolja/scbj/domain/member/service/MemberService.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/service/MemberService.java
@@ -74,12 +74,15 @@ public class MemberService {
 
 
     public void logout(final RefreshRequest refreshRequest) {
-        jwtUtil.setBlackList(refreshRequest.getAccessToken().substring(JwtUtil.GRANT_TYPE.length()), refreshRequest.getRefreshToken());
+        jwtUtil.setBlackList(refreshRequest.getAccessToken().substring(JwtUtil.GRANT_TYPE.length()),
+            refreshRequest.getRefreshToken());
     }
 
     public void updateMemberPassword(
         final MemberUpdatePasswordRequest memberUpdatePasswordRequest) {
-        getCurrentMember().updatePassword(
+        Member retrivedMember = memberRepository.findByEmail(memberUpdatePasswordRequest.email())
+            .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        retrivedMember.updatePassword(
             passwordEncoder.encode(memberUpdatePasswordRequest.password()));
     }
 

--- a/src/test/java/com/yanolja/scbj/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/yanolja/scbj/domain/member/service/MemberServiceTest.java
@@ -137,13 +137,15 @@ class MemberServiceTest {
             String changedPassword = "test1234!";
             String encodedPassword = passwordEncoder.encode("test1234!");
             MemberUpdatePasswordRequest memberUpdatePasswordRequest = MemberUpdatePasswordRequest.builder()
+                .email(testMember.getEmail())
                 .password(changedPassword).build();
-            given(memberRepository.findById(any())).willReturn(Optional.of(testMember));
+            given(memberRepository.findByEmail(any())).willReturn(Optional.of(testMember));
             given(passwordEncoder.encode(changedPassword)).willReturn(
                 encodedPassword);
             //when
             memberService.updateMemberPassword(memberUpdatePasswordRequest);
             //then
+            assertEquals(testMember.getEmail(), memberUpdatePasswordRequest.email());
             assertEquals(testMember.getPassword(), encodedPassword);
         }
 


### PR DESCRIPTION
# 😁 Issue Link
- Close #122 
# 😆 To Reviewers
- 비밀번호 찾기 - 비밀번호 수정 이 이루어집니다.
- 그렇기 때문에 해당 API에서 접속된 유저는 없고, 이메일로서 유저를 찾고 비밀번호를 수정해야 됩니다.
# 😚 Reference
- url 링크 (discussion)

# 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, **코드 수정을 강제하지 말아 주세요.**
* Reviewer 분들은 좋은 코드를 발견한 경우, **칭찬과 격려**를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **3일 이내에 진행**해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  * P1 : **꼭 반영해 주세요** (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  * P2 : 반영을 **적극적으로 고려**해 주시면 좋을 것 같아요 (Comment)
  * P3 : 이런 방법도 있을 것 같아요~ 등의 **사소한 의견**입니다 (Chore)
  