### PR TITLE
로그인 및 로그아웃 시 fcm token 저장 및 삭제

### DIFF
--- a/src/main/java/com/yanolja/scbj/domain/member/dto/request/MemberSignInRequest.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/dto/request/MemberSignInRequest.java
@@ -13,14 +13,16 @@ public record MemberSignInRequest(
         regexp = EMAIL_REGEX, groups = PatternGroup.class)
     String email,
     @Password(groups = PatternGroup.class)
-    String password
+    String password,
+    String fcmToken
 ) {
     private static final String EMAIL_REGEX = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
 
     @Builder
-    public MemberSignInRequest(String email, String password) {
+    public MemberSignInRequest(String email, String password, String fcmToken) {
         this.email = email;
         this.password = password;
+        this.fcmToken = fcmToken;
     }
 
 }

--- a/src/main/java/com/yanolja/scbj/domain/member/dto/request/RefreshRequest.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/dto/request/RefreshRequest.java
@@ -18,9 +18,12 @@ public class RefreshRequest {
     @NotBlank(groups = PatternGroup.class)
     private String refreshToken;
 
+    private String fcmToken;
+
     @Builder
-    private RefreshRequest(String accessToken, String refreshToken) {
+    private RefreshRequest(String accessToken, String refreshToken, String fcmToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/com/yanolja/scbj/domain/member/dto/request/RefreshRequest.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/dto/request/RefreshRequest.java
@@ -19,7 +19,7 @@ public class RefreshRequest {
     private String refreshToken;
 
     @Builder
-    private RefreshRequest(String accessToken, String refreshToken, String fcmToken) {
+    private RefreshRequest(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/yanolja/scbj/domain/member/dto/request/RefreshRequest.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/dto/request/RefreshRequest.java
@@ -18,12 +18,9 @@ public class RefreshRequest {
     @NotBlank(groups = PatternGroup.class)
     private String refreshToken;
 
-    private String fcmToken;
-
     @Builder
     private RefreshRequest(String accessToken, String refreshToken, String fcmToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/com/yanolja/scbj/domain/member/service/MemberAuthService.java
+++ b/src/main/java/com/yanolja/scbj/domain/member/service/MemberAuthService.java
@@ -29,18 +29,19 @@ public class MemberAuthService {
             throw new NotExpiredTokenException(ErrorCode.NOT_EXPIRED_TOKEN);
         } catch (ExpiredJwtException e) {
             username = e.getClaims().getSubject();
-        } finally {
-            if (jwtUtil.isRefreshTokenValid(username, refreshRequest.getRefreshToken())) {
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
-                String newAccessToken = jwtUtil.generateToken(userDetails);
-                String newRefreshToken = jwtUtil.generateRefreshToken(username);
+        }
 
-                return TokenResponse.builder().accessToken(newAccessToken)
-                    .refreshToken(newRefreshToken)
-                    .build();
-            } else {
-                throw new InvalidRefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
-            }
+        if (jwtUtil.isRefreshTokenValid(username, refreshRequest.getRefreshToken())) {
+            UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
+            String newAccessToken = jwtUtil.generateToken(userDetails);
+            String newRefreshToken = jwtUtil.generateRefreshToken(username);
+
+            return TokenResponse.builder().accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+
+        } else {
+            throw new InvalidRefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
     }
 }

--- a/src/main/java/com/yanolja/scbj/global/config/fcm/FCMService.java
+++ b/src/main/java/com/yanolja/scbj/global/config/fcm/FCMService.java
@@ -128,7 +128,9 @@ public class FCMService {
     }
 
     public void deleteToken(String email) {
-        fcmTokenRepository.deleteToken(email);
+        if(hasKey(email)) {
+            fcmTokenRepository.deleteToken(email);
+        }
     }
 
 

--- a/src/main/java/com/yanolja/scbj/global/config/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/com/yanolja/scbj/global/config/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.yanolja.scbj.global.config.jwt.exception;
+
+import com.yanolja.scbj.global.exception.ApplicationException;
+import com.yanolja.scbj.global.exception.ErrorCode;
+
+public class InvalidTokenException extends ApplicationException {
+
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/test/java/com/yanolja/scbj/domain/member/service/MemberAuthServiceTest.java
+++ b/src/test/java/com/yanolja/scbj/domain/member/service/MemberAuthServiceTest.java
@@ -9,6 +9,17 @@ import com.yanolja.scbj.domain.member.dto.response.TokenResponse;
 import com.yanolja.scbj.domain.member.helper.TestConstants;
 import com.yanolja.scbj.global.config.CustomUserDetailsService;
 import com.yanolja.scbj.global.config.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +50,8 @@ class MemberAuthServiceTest {
             .refreshToken(TestConstants.REFRESH_PREFIX.getValue())
             .build();
 
+
+        given(jwtUtil.extractUsername(any())).willThrow(new ExpiredJwtException(null, new ClaimImpl("1"),null));
         given(jwtUtil.isRefreshTokenValid(any(), any())).willReturn(true);
         given(jwtUtil.generateToken(any())).willReturn(TestConstants.GRANT_TYPE.getValue());
         given(jwtUtil.generateRefreshToken(any())).willReturn(
@@ -47,5 +60,212 @@ class MemberAuthServiceTest {
         //when & then
         assertThat(tokenResponse).usingRecursiveComparison()
             .isEqualTo(memberAuthService.refreshAccessToken(refreshRequest));
+    }
+
+    class ClaimImpl implements Claims{
+
+        private String username;
+        public ClaimImpl(String username) {
+
+        }
+        @Override
+        public String getIssuer() {
+            return null;
+        }
+
+        @Override
+        public Claims setIssuer(String iss) {
+            return null;
+        }
+
+        @Override
+        public String getSubject() {
+            return username;
+        }
+
+        @Override
+        public Claims setSubject(String sub) {
+            return null;
+        }
+
+        @Override
+        public String getAudience() {
+            return null;
+        }
+
+        @Override
+        public Claims setAudience(String aud) {
+            return null;
+        }
+
+        @Override
+        public Date getExpiration() {
+            return null;
+        }
+
+        @Override
+        public Claims setExpiration(Date exp) {
+            return null;
+        }
+
+        @Override
+        public Date getNotBefore() {
+            return null;
+        }
+
+        @Override
+        public Claims setNotBefore(Date nbf) {
+            return null;
+        }
+
+        @Override
+        public Date getIssuedAt() {
+            return null;
+        }
+
+        @Override
+        public Claims setIssuedAt(Date iat) {
+            return null;
+        }
+
+        @Override
+        public String getId() {
+            return null;
+        }
+
+        @Override
+        public Claims setId(String jti) {
+            return null;
+        }
+
+        @Override
+        public <T> T get(String claimName, Class<T> requiredType) {
+            return null;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return false;
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return false;
+        }
+
+        @Override
+        public Object get(Object key) {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Object put(String key, Object value) {
+            return null;
+        }
+
+        @Override
+        public Object remove(Object key) {
+            return null;
+        }
+
+        @Override
+        public void putAll(@NotNull Map<? extends String, ?> m) {
+
+        }
+
+        @Override
+        public void clear() {
+
+        }
+
+        @NotNull
+        @Override
+        public Set<String> keySet() {
+            return null;
+        }
+
+        @NotNull
+        @Override
+        public Collection<Object> values() {
+            return null;
+        }
+
+        @NotNull
+        @Override
+        public Set<Entry<String, Object>> entrySet() {
+            return null;
+        }
+
+        @Override
+        public Object getOrDefault(Object key, Object defaultValue) {
+            return Claims.super.getOrDefault(key, defaultValue);
+        }
+
+        @Override
+        public void forEach(BiConsumer<? super String, ? super Object> action) {
+            Claims.super.forEach(action);
+        }
+
+        @Override
+        public void replaceAll(BiFunction<? super String, ? super Object, ?> function) {
+            Claims.super.replaceAll(function);
+        }
+
+        @Nullable
+        @Override
+        public Object putIfAbsent(String key, Object value) {
+            return Claims.super.putIfAbsent(key, value);
+        }
+
+        @Override
+        public boolean remove(Object key, Object value) {
+            return Claims.super.remove(key, value);
+        }
+
+        @Override
+        public boolean replace(String key, Object oldValue, Object newValue) {
+            return Claims.super.replace(key, oldValue, newValue);
+        }
+
+        @Nullable
+        @Override
+        public Object replace(String key, Object value) {
+            return Claims.super.replace(key, value);
+        }
+
+        @Override
+        public Object computeIfAbsent(String key,
+            @NotNull Function<? super String, ?> mappingFunction) {
+            return Claims.super.computeIfAbsent(key, mappingFunction);
+        }
+
+        @Override
+        public Object computeIfPresent(String key,
+            @NotNull BiFunction<? super String, ? super Object, ?> remappingFunction) {
+            return Claims.super.computeIfPresent(key, remappingFunction);
+        }
+
+        @Override
+        public Object compute(String key,
+            @NotNull BiFunction<? super String, ? super Object, ?> remappingFunction) {
+            return Claims.super.compute(key, remappingFunction);
+        }
+
+        @Override
+        public Object merge(String key, @NotNull Object value,
+            @NotNull BiFunction<? super Object, ? super Object, ?> remappingFunction) {
+            return Claims.super.merge(key, value, remappingFunction);
+        }
     }
 }

--- a/src/test/java/com/yanolja/scbj/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/yanolja/scbj/domain/member/service/MemberServiceTest.java
@@ -21,6 +21,7 @@ import com.yanolja.scbj.domain.member.helper.TestConstants;
 import com.yanolja.scbj.domain.member.repository.MemberRepository;
 import com.yanolja.scbj.domain.member.repository.YanoljaMemberRepository;
 import com.yanolja.scbj.domain.member.util.MemberMapper;
+import com.yanolja.scbj.global.config.fcm.FCMService;
 import com.yanolja.scbj.global.config.jwt.JwtUtil;
 import com.yanolja.scbj.global.util.SecurityUtil;
 import java.util.Optional;
@@ -45,6 +46,9 @@ class MemberServiceTest {
     private JwtUtil jwtUtil;
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private FCMService fcmService;
 
     @Mock
     private YanoljaMemberRepository yanoljaMemberRepository;
@@ -124,8 +128,13 @@ class MemberServiceTest {
                 .accessToken(TestConstants.GRANT_TYPE.getValue())
                 .refreshToken(TestConstants.REFRESH_PREFIX.getValue()).build();
 
-            //when & then
+            // when
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+            given(memberRepository.findById(1L)).willReturn(Optional.of(testMember));
+            given(jwtUtil.extractUsername(any())).willReturn("1");
+            given(jwtUtil.isRefreshTokenValid(any(), any())).willReturn(true);
             memberService.logout(refreshRequest);
+            // then
             verify(jwtUtil, times(1)).setBlackList(refreshRequest.getAccessToken().substring(7),
                 refreshRequest.getRefreshToken());
         }


### PR DESCRIPTION
# 😁 Issue Link
- Close #184 
# 😆 To Reviewers
- 로그인할 때, FCM 토큰을 생성해야 알림을 보낼 수 있습니다.
- 현재는 FE쪽에서 알림에 대한 준비가 안되있으니 FCM TOKEN 이 null값이면 저장 로직을 스킵하고 원래의 로그인, 로그아웃 로직을 수행합니다.

# 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, **코드 수정을 강제하지 말아 주세요.**
* Reviewer 분들은 좋은 코드를 발견한 경우, **칭찬과 격려**를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 **3일 이내에 진행**해 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
  * P1 : **꼭 반영해 주세요** (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
  * P2 : 반영을 **적극적으로 고려**해 주시면 좋을 것 같아요 (Comment)
  * P3 : 이런 방법도 있을 것 같아요~ 등의 **사소한 의견**입니다 (Chore)
  